### PR TITLE
Feature/multiple source path

### DIFF
--- a/skybar/src/main/java/org/wtf/skybar/web/SourceLister.java
+++ b/skybar/src/main/java/org/wtf/skybar/web/SourceLister.java
@@ -50,12 +50,12 @@ public class SourceLister extends ResourceHandler {
         for (Resource base: this.searchPaths) {
             this.setBaseResource(base);
             result = super.getResource(path);
-            if (result != null) {
+            if (result != null && result.exists()) {
                 LOG.debug("Skybar source "+path+" found: "+result);
                 break;
             }
         }
-        if (result == null) {
+        if (result == null || !result.exists()) {
             LOG.warn("Skybar source NOT found: "+path);
         }
         return result;

--- a/skybar/src/test/java/org/wtf/skybar/web/SourceListerTest.java
+++ b/skybar/src/test/java/org/wtf/skybar/web/SourceListerTest.java
@@ -1,0 +1,59 @@
+package org.wtf.skybar.web;
+
+import org.eclipse.jetty.util.resource.Resource;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+public class SourceListerTest {
+    @Test
+    public void testGetExistingResourceSinglePath() throws IOException {
+        // Set up
+        final SourceLister instance = new SourceLister(
+            "src/test/resources/source_dir"
+        );
+
+        // Test
+        final Resource actualResource = instance.getResource("/file");
+
+        // Verify
+        assertNotNull(actualResource);
+        assertTrue(actualResource.exists());
+    }
+
+    @Test
+    public void testGetExistingResourceMultiplePaths() throws IOException {
+        // Set up
+        final SourceLister instance = new SourceLister(
+            "src/test/resources/empty" +
+            System.getProperty("path.separator") +
+            "src/test/resources/source_dir"
+        );
+
+        // Test
+        final Resource actualResource = instance.getResource("/file");
+
+        // Verify
+        assertNotNull(actualResource);
+        assertTrue(actualResource.exists());
+    }
+
+    @Test
+    public void testGetMissingResource() throws IOException {
+        // Set up
+        final SourceLister instance = new SourceLister(
+            "src/test/resources/empty" +
+            System.getProperty("path.separator") +
+            "src/test/resources/source_dir"
+        );
+
+        // Test
+        final Resource actualResource = instance.getResource("/non-existent");
+
+        // Verify
+        assertNotNull(actualResource);
+        assertFalse(actualResource.exists());
+    }
+}

--- a/skybar/src/test/resources/source_dir/file
+++ b/skybar/src/test/resources/source_dir/file
@@ -1,0 +1,1 @@
+Just a file.


### PR DESCRIPTION
Updated the SourceLister to support multiple source paths. I think this feature was intended, but not working correctly because it was erroneously assuming that a non-null getResource response means the resource exists, when in fact, an additional check (resource#exists()) is needed.
