### PR TITLE
Added support for inner classes by allowing *class names* with '$'s, …

### DIFF
--- a/skybar/src/main/java/org/wtf/skybar/transform/SkybarClassVisitor.java
+++ b/skybar/src/main/java/org/wtf/skybar/transform/SkybarClassVisitor.java
@@ -32,7 +32,9 @@ class SkybarClassVisitor extends ClassVisitor implements Opcodes {
     @Override
     public void visitSource(String source, String debug) {
         super.visitSource(source, debug);
-        this.sourceFile = className.substring(0, className.lastIndexOf("/") + 1) + source;
+        if (source.indexOf('$') == -1) {
+            this.sourceFile = className.substring(0, className.lastIndexOf("/") + 1) + source;
+        }
     }
 
     @Override

--- a/skybar/src/main/java/org/wtf/skybar/transform/SkybarTransformer.java
+++ b/skybar/src/main/java/org/wtf/skybar/transform/SkybarTransformer.java
@@ -64,6 +64,6 @@ public class SkybarTransformer implements ClassFileTransformer {
         }
         // Ok, do we match our pattern?
         // TODO figure out what to do with classes we can't find source for
-        return pattern.matcher(className).matches() && !className.contains("$$");
+        return pattern.matcher(className).matches();
     }
 }


### PR DESCRIPTION
Added support for inner classes by filtering out only _source file names_ with '$' in them (which generally indicates generated sources), instead of filtering out any _class name_ with '$' in them.

In other words, if a class name has '$' in it, but its source file does not have '$' in it, we want to instrument it.

Note that I tried updating tests to verify this case, but the testing framework wasn't quite handling inner classes correctly. I'll have a look at this later.
